### PR TITLE
Remove node v0.8 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - 0.8
   - 0.10
   - 0.11


### PR DESCRIPTION
Due to devDependencies utilizing the `^` version operator in their dependencies,
and node 0.8's version of npm being incompatible with it, the travis builds fail.
Also, I think we can stop consciously supporting node v0.8 now.