### PR TITLE
Handle boolean case

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -32,6 +32,9 @@ encode._encode = function( buffers, data ) {
         ? encode.list( buffers, data )
         : encode.dict( buffers, data )
       break
+    case 'boolean':
+      encode.number( buffers, data ? 1 : 0 )
+      break
   }
 
 }


### PR DESCRIPTION
@jhermsmeier @themasch 

Convert boolean values to 0/1. 

I wasn't sure if this was "proper" behavior and something that should be included since booleans are not really supported. It helped in my case since I didn't want to have to convert all boolean values before sending the bencode message. I think at the very least there should be some error handling for this case.