### PR TITLE
Implement the `abstract-encoding` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,18 +140,28 @@ var result = bencode.decode( data, 'utf8' )
 
 ## API
 
-### bencode.encode( *data* )
+The API is compatible with the [`abstract-encoding`](https://github.com/mafintosh/abstract-encoding) specification.
 
-> `Buffer` | `Array` | `String` | `Object` | `Number` __data__
+### bencode.encode( *data*, *[buffer]*, *[offset]* )
+
+> `Buffer` | `Array` | `String` | `Object` | `Number` | `Boolean` __data__
+> `Buffer` __buffer__
+> `Number` __offset__
 
 Returns `Buffer`
 
-### bencode.decode( *data*, *encoding* )
+### bencode.decode( *data*, *[start]*, *[end]*, *[encoding]* )
 
 > `Buffer` __data__
+> `Number` __start__
+> `Number` __end__
 > `String` __encoding__
 
 If `encoding` is set, bytestrings are
 automatically converted to strings.
 
 Returns `Object` | `Array` | `Buffer` | `String` | `Number`
+
+### bencode.byteLength( *value* ) or bencode.encodingLength( *value* )
+
+> `Buffer` | `Array` | `String` | `Object` | `Number` | `Boolean` __value__

--- a/benchmark/encoding-length.js
+++ b/benchmark/encoding-length.js
@@ -1,0 +1,33 @@
+var fs = require( 'fs' )
+var bencode = require( '..' )
+
+var buffer = fs.readFileSync( __dirname + '/test.torrent' )
+var torrent = bencode.decode( buffer )
+
+suite( 'encoding length', function() {
+  
+  bench( 'torrent', function() {
+    bencode.encodingLength( torrent )
+  })
+  
+  bench( 'buffer', function() {
+    bencode.encodingLength( buffer )
+  })
+  
+  bench( 'string', function() {
+    bencode.encodingLength( 'Test, test, this is a string' )
+  })
+  
+  bench( 'number', function() {
+    bencode.encodingLength( 87641234567 )
+  })
+  
+  bench( 'array<number>', function() {
+    bencode.encodingLength([ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ])
+  })
+  
+  bench( 'small object', function() {
+    bencode.encodingLength({ a: 1, b: 'c', d: 'abcdefg', e: [1,2,3] })
+  })
+  
+})

--- a/bencode.js
+++ b/bencode.js
@@ -1,4 +1,14 @@
-module.exports = {
-  encode: require( './lib/encode' ),
-  decode: require( './lib/decode' )
+var bencode = module.exports
+
+bencode.encode = require( './lib/encode' )
+bencode.decode = require( './lib/decode' )
+
+/**
+ * Determines the amount of bytes
+ * needed to encode the given value
+ * @param  {Object|Array|Buffer|String|Number|Boolean} value
+ * @return {Number} byteCount
+ */
+bencode.byteLength = bencode.encodingLength = function( value ) {
+  return bencode.encode( value ).length
 }

--- a/lib/decode.js
+++ b/lib/decode.js
@@ -4,22 +4,37 @@ var Dict = require("./dict")
  * Decodes bencoded data.
  *
  * @param  {Buffer} data
- * @param  {String} encoding
+ * @param  {Number} start (optional)
+ * @param  {Number} end (optional)
+ * @param  {String} encoding (optional)
  * @return {Object|Array|Buffer|String|Number}
  */
-function decode( data, encoding ) {
-
+function decode( data, start, end, encoding ) {
+  
+  if( typeof start !== 'number' && encoding == null ) {
+    encoding = start
+    start = undefined
+  }
+  
+  if( typeof end !== 'number' && encoding == null ) {
+    encoding = end
+    end = undefined
+  }
+  
   decode.position = 0
   decode.encoding = encoding || null
 
   decode.data = !( Buffer.isBuffer(data) )
     ? new Buffer( data )
-    : data
-
+    : data.slice( start, end )
+  
+  decode.bytes = decode.data.length
+  
   return decode.next()
 
 }
 
+decode.bytes = 0
 decode.position = 0
 decode.data     = null
 decode.encoding = null
@@ -30,7 +45,7 @@ decode.next = function() {
     case 0x64: return decode.dictionary(); break
     case 0x6C: return decode.list(); break
     case 0x69: return decode.integer(); break
-    default:   return decode.bytes(); break
+    default:   return decode.buffer(); break
   }
 
 }
@@ -62,7 +77,7 @@ decode.dictionary = function() {
   var dict = new Dict()
 
   while( decode.data[decode.position] !== 0x65 ) {
-    dict.binarySet(decode.bytes(), decode.next())
+    dict.binarySet(decode.buffer(), decode.next())
   }
 
   decode.position++
@@ -98,7 +113,7 @@ decode.integer = function() {
 
 }
 
-decode.bytes = function() {
+decode.buffer = function() {
 
   var sep    = decode.find( 0x3A )
   var length = parseInt( decode.data.toString( 'ascii', decode.position, sep ), 10 )

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -1,15 +1,28 @@
 /**
  * Encodes data in bencode.
  *
- * @param  {Buffer|Array|String|Object|Number} data
+ * @param  {Buffer|Array|String|Object|Number|Boolean} data
  * @return {Buffer}
  */
-function encode( data ) {
+function encode( data, buffer, offset ) {
+  
   var buffers = []
+  var result = null
+  
   encode._encode( buffers, data )
-  return Buffer.concat( buffers )
+  result = Buffer.concat( buffers )
+  encode.bytes = result.length
+  
+  if( Buffer.isBuffer( buffer ) ) {
+    result.copy( buffer, offset )
+    return buffer
+  }
+  
+  return result
+  
 }
 
+encode.bytes = -1
 encode._floatConversionDetected = false
 
 encode._encode = function( buffers, data ) {
@@ -22,7 +35,7 @@ encode._encode = function( buffers, data ) {
 
   switch( typeof data ) {
     case 'string':
-      encode.bytes( buffers, data )
+      encode.buffer( buffers, data )
       break
     case 'number':
       encode.number( buffers, data )
@@ -43,7 +56,7 @@ var buff_e = new Buffer('e')
   , buff_d = new Buffer('d')
   , buff_l = new Buffer('l')
 
-encode.bytes = function( buffers, data ) {
+encode.buffer = function( buffers, data ) {
 
   buffers.push( new Buffer(Buffer.byteLength( data ) + ':' + data) )
 }
@@ -79,7 +92,7 @@ encode.dict = function( buffers, data ) {
 
   for( ; j < kl ; j++) {
     k=keys[j]
-    encode.bytes( buffers, k )
+    encode.buffer( buffers, k )
     encode._encode( buffers, data[k] )
   }
 

--- a/test/abstract-encoding.test.js
+++ b/test/abstract-encoding.test.js
@@ -1,0 +1,62 @@
+var bencode = require( '..' )
+var test = require( 'tape' ).test
+
+test( 'abstract encoding', function( t ) {
+  
+  t.test( 'encodingLength( value )', function( t ) {
+    var input = { string: 'Hello World', integer: 12345 }
+    var output = new Buffer( 'd7:integeri12345e6:string11:Hello Worlde' )
+    t.plan( 1 )
+    t.equal( bencode.encodingLength( input ), output.length )
+  })
+  
+  t.test( 'encode.bytes', function( t ) {
+    var output = bencode.encode({ string: 'Hello World', integer: 12345 })
+    t.plan( 1 )
+    t.equal( output.length, bencode.encode.bytes )
+  })
+  
+  t.test( 'encode into an existing buffer', function( t ) {
+    var input = { string: 'Hello World', integer: 12345 }
+    var output = new Buffer( 'd7:integeri12345e6:string11:Hello Worlde' )
+    var target = new Buffer( output.length )
+    bencode.encode( input, target )
+    t.plan( 1 )
+    t.deepEqual( target, output )
+  })
+  
+  t.test( 'encode into a buffer with an offset', function( t ) {
+    var input = { string: 'Hello World', integer: 12345 }
+    var output = new Buffer( 'd7:integeri12345e6:string11:Hello Worlde' )
+    var target = new Buffer( 64 + output.length ) // Pad with 64 bytes
+    var offset = 48
+    bencode.encode( input, target, offset )
+    t.plan( 1 )
+    t.deepEqual( target.slice( offset, offset + output.length ), output )
+  })
+  
+  t.test( 'decode.bytes', function( t ) {
+    var input = new Buffer( 'd7:integeri12345e6:string11:Hello Worlde' )
+    var output = bencode.decode( input )
+    t.plan( 1 )
+    t.equal( bencode.decode.bytes, input.length )
+  })
+  
+  t.test( 'decode from an offset', function( t ) {
+    var pad = '_______________________________'
+    var input = new Buffer( pad + 'd7:integeri12345e6:string11:Hello Worlde' )
+    var output = bencode.decode( input, pad.length, 'utf8' )
+    t.plan( 1 )
+    t.deepEqual( output, { string: 'Hello World', integer: 12345 })
+  })
+  
+  t.test( 'decode between an offset and end', function( t ) {
+    var pad = '_______________________________'
+    var data = 'd7:integeri12345e6:string11:Hello Worlde'
+    var input = new Buffer( pad + data + pad )
+    var output = bencode.decode( input, pad.length, pad.length + data.length, 'utf8' )
+    t.plan( 1 )
+    t.deepEqual( output, { string: 'Hello World', integer: 12345 })
+  })
+  
+})


### PR DESCRIPTION
See #37 and https://github.com/mafintosh/abstract-encoding

Implements the following API in a backwards-compatible fashion (meaning: no major version bump necessary):
```
byteCount = bencode.encodingLength(value)
buffer = bencode.encode(value, [buffer], [offset])
value = bencode.decode(buffer, [start], [end], [encoding])
```

**TODO:**
- [x] Update `README.md` with new API documentation
- [x] Add tests for `abstract-encoding` API
- [x] Add benchmarks

**NOTE:** It has a minor effect on performance (aournd 500-1000 op/s on my machine)