### PR TITLE
Fix string to be decoded in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ d4:dictd3:key36:This is a string within a dictionarye7:integeri12345e4:listli1ei
 ### Decoding
 
 ```javascript
-var data   = new Buffer( 'd6:string11:Hello World7:integeri12345e4:dictd3:key36:This is a string within a dictionarye4:litli1ei2ei3ei4e6:stringi5edeee' )
+var data   = new Buffer( 'd6:string11:Hello World7:integeri12345e4:dictd3:key36:This is a string within a dictionarye4:listli1ei2ei3ei4e6:stringi5edeee' )
 var result = bencode.decode( data )
 ```
 


### PR DESCRIPTION
A `s` was missing in the example string to be decoded :)