### PR TITLE
Ignore null-values when encoding

### DIFF
--- a/lib/decode.js
+++ b/lib/decode.js
@@ -49,6 +49,10 @@ function getIntFromBuffer (buffer, start, end) {
  * @return {Object|Array|Buffer|String|Number}
  */
 function decode (data, start, end, encoding) {
+  if (data == null || data.length === 0) {
+    return null
+  }
+
   if (typeof start !== 'number' && encoding == null) {
     encoding = start
     start = undefined

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -30,6 +30,8 @@ encode._encode = function (buffers, data) {
     return
   }
 
+  if (data == null) { return }
+
   switch (typeof data) {
     case 'string':
       encode.buffer(buffers, data)
@@ -85,6 +87,7 @@ encode.dict = function (buffers, data) {
 
   for (; j < kl; j++) {
     k = keys[j]
+    if (data[k] == null) continue
     encode.buffer(buffers, k)
     encode._encode(buffers, data[k])
   }
@@ -98,6 +101,7 @@ encode.list = function (buffers, data) {
   buffers.push(buffL)
 
   for (; i < c; i++) {
+    if (data[i] == null) continue
     encode._encode(buffers, data[i])
   }
 

--- a/test/null-values.test.js
+++ b/test/null-values.test.js
@@ -1,0 +1,24 @@
+var bencode = require('..')
+var test = require('tape').test
+
+test('Data with null values', function (t) {
+  t.test('should return an empty value when encoding either null or undefined', function (t) {
+    t.plan(2)
+    t.deepEqual(bencode.encode(null), new Buffer(0))
+    t.deepEqual(bencode.encode(undefined), new Buffer(0))
+  })
+
+  t.test('should return null when decoding an empty value', function (t) {
+    t.plan(2)
+    t.deepEqual(bencode.decode(new Buffer(0)), null)
+    t.deepEqual(bencode.decode(''), null)
+  })
+
+  t.test('should omit null values when encoding', function (t) {
+    var data = [ { empty: null }, { notset: undefined }, null, undefined, 0 ]
+    var result = bencode.decode(bencode.encode(data))
+    var expected = [ {}, {}, 0 ]
+    t.plan(1)
+    t.deepEqual(result, expected)
+  })
+})


### PR DESCRIPTION
**Description**

Currently, when encoding objects of any kind, values that are either `null` or `undefined` will throw `TypeError: Cannot read property 'constructor' of null` because we don't even check for those.

As it can become very cumbersome to remove any keys (or items) with null-values when working with more complex data structures, I propose ignoring null-values during encoding, so that they'll be left out in the encoded data.

This change should theoretically be backwards compatible, if I haven't missed anything.

**Changes**

- `bencode.decode()` now returns `null` if fed with empty values (`''` or `new Buffer(0)`)
- `bencode.encode()` and parts now skip / ignore `null` and `undefined` in Arrays and Objects
- `bencode.encode()` now returns an empty Buffer / String when invoked on `null` or `undefined`

**Example**

```js
bencode.encode([
  { empty: null },
  { notset: undefined },
  null,
  undefined,
  0
])
```
Will now encode to the following (instead of throwing):
```js
[ {}, {}, 0 ]
```