### PR TITLE
Update tested node versions on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-  - 0.10
-  - 0.11
-  - 0.12
-  - 4
   - stable
+  - 6
+  - 4
 branches:
   only:
     - master


### PR DESCRIPTION
I think we can now safely get rid of the `0.x` versions,
as those have been deprecated a wee while ago.