### PR TITLE
Remove Testling CI badge & package.json info

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ var bencode = require( 'bencode' )
 
 You can also use node-bencode with browserify to be able to use it in a lot of modern browsers.
 
-[![testling results](https://ci.testling.com/themasch/node-bencode.png)](https://ci.testling.com/themasch/node-bencode)
-
 ### Encoding
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -43,18 +43,5 @@
   "scripts": {
     "bench": "matcha",
     "test": "standard && tape test/*.test.js | tap-spec"
-  },
-  "testling": {
-    "files": "test/*.test.js",
-    "browsers": [
-      "ie/6..latest",
-      "chrome/22..latest",
-      "firefox/16..latest",
-      "safari/latest",
-      "opera/11.0..latest",
-      "iphone/6..latest",
-      "ipad/6..latest",
-      "android-browser/latest"
-    ]
   }
 }


### PR DESCRIPTION
Since Testling has been non-functional for more than 2 years now, this can be removed for now, and maybe added back when Testling works again. If at all – who knows how likely that is.