### PR TITLE
Improve encoding type checks

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -25,30 +25,28 @@ function encode (data, buffer, offset) {
 encode.bytes = -1
 encode._floatConversionDetected = false
 
-encode._encode = function (buffers, data) {
-  if (Buffer.isBuffer(data)) {
-    buffers.push(Buffer.from(data.length + ':'))
-    buffers.push(data)
-    return
-  }
+encode.getType = function (value) {
+  if (Buffer.isBuffer(value)) return 'buffer'
+  if (Array.isArray(value)) return 'array'
+  if (ArrayBuffer.isView(value)) return 'typedarray'
+  if (value instanceof Number) return 'number'
+  if (value instanceof Boolean) return 'boolean'
+  if (value instanceof ArrayBuffer) return 'arraybuffer'
+  return typeof value
+}
 
+encode._encode = function (buffers, data) {
   if (data == null) { return }
 
-  switch (typeof data) {
-    case 'string':
-      encode.buffer(buffers, data)
-      break
-    case 'number':
-      encode.number(buffers, data)
-      break
-    case 'object':
-      data.constructor === Array
-        ? encode.list(buffers, data)
-        : encode.dict(buffers, data)
-      break
-    case 'boolean':
-      encode.number(buffers, data ? 1 : 0)
-      break
+  switch (encode.getType(data)) {
+    case 'buffer': encode.buffer(buffers, data); break
+    case 'object': encode.dict(buffers, data); break
+    case 'array': encode.list(buffers, data); break
+    case 'string': encode.string(buffers, data); break
+    case 'number': encode.number(buffers, data); break
+    case 'boolean': encode.number(buffers, data); break
+    case 'typedarray': encode.buffer(buffers, Buffer.from(data.buffer)); break
+    case 'arraybuffer': encode.buffer(buffers, Buffer.from(data)); break
   }
 }
 
@@ -57,6 +55,10 @@ var buffD = Buffer.from('d')
 var buffL = Buffer.from('l')
 
 encode.buffer = function (buffers, data) {
+  buffers.push(new Buffer(data.length + ':'), data)
+}
+
+encode.string = function (buffers, data) {
   buffers.push(Buffer.from(Buffer.byteLength(data) + ':' + data))
 }
 
@@ -90,7 +92,7 @@ encode.dict = function (buffers, data) {
   for (; j < kl; j++) {
     k = keys[j]
     if (data[k] == null) continue
-    encode.buffer(buffers, k)
+    encode.string(buffers, k)
     encode._encode(buffers, data[k])
   }
 

--- a/test/encode.test.js
+++ b/test/encode.test.js
@@ -116,4 +116,53 @@ test('bencode#encode()', function (t) {
     t.equal(bencode.encode({'a': '45', 'b': 45}).toString(), 'd1:a2:451:bi45ee')
     t.equal(bencode.encode({'a': Buffer.from('bc')}).toString(), 'd1:a2:bce')
   })
+
+  t.test('should encode new Number(1) as number', function (t) {
+    var data = new Number(1) // eslint-disable-line
+    var result = bencode.decode(bencode.encode(data))
+    var expected = 1
+    t.plan(1)
+    t.strictEqual(result, expected)
+  })
+
+  t.test('should encode new Boolean(true) as number', function (t) {
+    var data = new Boolean(true) // eslint-disable-line
+    var result = bencode.decode(bencode.encode(data))
+    var expected = 1
+    t.plan(1)
+    t.strictEqual(result, expected)
+  })
+
+  t.test('should encode Uint8Array as buffer', function (t) {
+    var data = new Uint8Array([ 1, 2, 3, 4, 5, 6, 7, 8, 9 ])
+    var result = bencode.decode(bencode.encode(data))
+    var expected = Buffer.from(data.buffer)
+    t.plan(1)
+    t.deepEqual(result, expected)
+  })
+
+  t.test('should encode Uint32Array as buffer', function (t) {
+    var data = new Uint32Array([ 0xF, 0xFF, 0xFFF, 0xFFFF, 0xFFFFF, 0xFFFFFF, 0xFFFFFFF, 0xFFFFFFFF ])
+    var result = bencode.decode(bencode.encode(data))
+    var expected = Buffer.from(data.buffer)
+    t.plan(1)
+    t.deepEqual(result, expected)
+  })
+
+  t.test('should encode ArrayBuffer as buffer', function (t) {
+    var data = new Uint32Array([ 0xF, 0xFF, 0xFFF, 0xFFFF, 0xFFFFF, 0xFFFFFF, 0xFFFFFFF, 0xFFFFFFFF ])
+    var result = bencode.decode(bencode.encode(data.buffer))
+    var expected = Buffer.from(data.buffer)
+    t.plan(1)
+    t.deepEqual(result, expected)
+  })
+
+  t.test('should encode Float32Array as buffer', function (t) {
+    var data = new Float32Array([ 1.2, 2.3, 3.4, 4.5, 5.6, 6.7, 7.8, 8.9, 9.0 ])
+    var result = bencode.decode(bencode.encode(data))
+    var expected = Buffer.from(data.buffer)
+    console.log(result)
+    t.plan(1)
+    t.deepEqual(result, expected)
+  })
 })


### PR DESCRIPTION
**Changes:**

Adds a check for typed Arrays by utilizing `ArrayBuffer.isView()`, which seems to be the safest & fastest way to check for that (?), and also considers DataViews.
Also adds checks for Numbers & Booleans constructed via `new Number(x)` and `new Boolean(x)`, which ideally shouldn't be done anywhere, but it wouldn't hurt to handle those correctly as well.

Typed arrays are now encoded raw as buffers (not as dictionaries or lists), meaning that for example, a Float32Array will be encoded as a Buffer which the floats can be read back from with `buffer.readFloat32LE()`, as demonstrated below:

```js
> var data = new Float32Array([ 1.2, 2.3, 3.4, 4.5, 5.6, 6.7, 7.8, 8.9, 9.0 ])
> var b = Buffer.from(data.buffer)
> b
<Buffer 9a 99 99 3f 33 33 13 40 9a 99 59 40 00 00 90 40 33 33 b3 40 66 66 d6 40 9a 99 f9 40 66 66 0e 41 00 00 10 41>
> b.readFloatLE(0)
1.2000000476837158
```

**To Do:**
- [x] Add tests

**See also:**
- #63 browserify not work

**Depends on:**
- #77 test(ci): Drop Node v0.10.x & v0.12.x, add 8.x.x