### PR TITLE
Remove unused mocha.opts, add script to standard --fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "scripts": {
     "bench": "matcha",
+    "style": "standard --fix",
     "test": "standard && tape test/*.test.js | tap-spec"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---reporter spec


### PR DESCRIPTION
- Adds `npm run style` to auto-fix code style and improve laziness efficiency
- Remove `mocha.opts`, which hasn't been in use for ages