### PR TITLE
Support Node 0.10, 0.12, and early Node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
   - stable
   - 6
   - 4
+  - "0.12"
+  - "0.10"
 branches:
   only:
     - master

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -1,3 +1,5 @@
+var Buffer = require('safe-buffer').Buffer
+
 /**
  * Encodes data in bencode.
  *

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "bench": "matcha",
     "style": "standard --fix",
     "test": "standard && tape test/*.test.js | tap-spec"
+  },
+  "dependencies": {
+    "safe-buffer": "^5.1.1"
   }
 }

--- a/test/BEP-0023.test.js
+++ b/test/BEP-0023.test.js
@@ -2,6 +2,7 @@ var bencode = require('..')
 var path = require('path')
 var fs = require('fs')
 var test = require('tape').test
+var Buffer = require('safe-buffer').Buffer
 
 // @see http://www.bittorrent.org/beps/bep_0023.html
 test('BEP 0023', function (t) {

--- a/test/abstract-encoding.test.js
+++ b/test/abstract-encoding.test.js
@@ -1,5 +1,6 @@
 var bencode = require('..')
 var test = require('tape').test
+var Buffer = require('safe-buffer').Buffer
 
 test('abstract encoding', function (t) {
   t.test('encodingLength( value )', function (t) {

--- a/test/data.js
+++ b/test/data.js
@@ -1,3 +1,4 @@
+var Buffer = require('safe-buffer').Buffer
 module.exports = {
   binKeyData: Buffer.from('ZDU6ZmlsZXNkMzY6N++/vVXvv73go5rvv71L77+9z6fXlu+/ve+/ve+/ve+/vSR3ZDg6Y29tcGxldGVpMGUxMDpkb3dubG9hZGVkaTEwZTEwOmluY29tcGxldGVpMGVlZWU=', 'base64'),
   binKeyName: Buffer.from('N++/vVXvv73go5rvv71L77+9z6fXlu+/ve+/ve+/ve+/vSR3', 'base64'),

--- a/test/decode.buffer.test.js
+++ b/test/decode.buffer.test.js
@@ -1,6 +1,7 @@
 var bencode = require('..')
 var data = require('./data')
 var test = require('tape').test
+var Buffer = require('safe-buffer').Buffer
 
 test('bencode#decode(x)', function (t) {
   t.test('should be able to decode an integer', function (t) {

--- a/test/encode.test.js
+++ b/test/encode.test.js
@@ -1,6 +1,7 @@
 var bencode = require('..')
 var data = require('./data.js')
 var test = require('tape').test
+var Buffer = require('safe-buffer').Buffer
 
 test('bencode#encode()', function (t) {
   // prevent the warning showing up in the test

--- a/test/null-values.test.js
+++ b/test/null-values.test.js
@@ -1,5 +1,6 @@
 var bencode = require('..')
 var test = require('tape').test
+var Buffer = require('safe-buffer').Buffer
 
 test('Data with null values', function (t) {
   t.test('should return an empty value when encoding either null or undefined', function (t) {


### PR DESCRIPTION
We support these node versions in `bittorrent-dht` and they lack the
new Buffer.from, etc. methods.

`safe-buffer` provides a buffer with the new methods, or does nothing
if the node version is new enough.