### PR TITLE
test(ci): Drop Node v0.10.x & v0.12.x, add 8.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: node_js
-sudo: false
 node_js:
   - stable
+  - 8
   - 6
   - 4
-  - "0.12"
-  - "0.10"
-branches:
-  only:
-    - master
-script: npm test
+script:
+  - npm test


### PR DESCRIPTION
BREAKING CHANGE: This drops support Node v0.10.x, and v0.12.x
while adding Node v8.x.x, as v9.x.x is now stable.