### PR TITLE
Release/2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0
+
+- Drop support for Node 0.10, 0.12., add support for Node 8 & 9  (@jhermsmeier)
+- support for typed arrays (@jhermsmeier, @nazar-pc)
+
 ## 1.0.0
 
 - Support Node 0.10, 0.12, and early Node 4 (@feross)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.0.0
 
 - Drop support for Node 0.10, 0.12., add support for Node 8 & 9  (@jhermsmeier)
-- support for typed arrays (@jhermsmeier, @nazar-pc)
+- Support for typed arrays (@jhermsmeier, @nazar-pc)
 
 ## 1.0.0
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,3 +7,4 @@ Jeffrey Hwang <kaelar@gmail.com>
 Sean Lang <slang800@gmail.com>
 Nicolas Gotchac <ngotchac@gmail.com>
 Feross Aboukhadijeh <feross@feross.org>
+Nazar Mokrynskyi <nazar@mokrynskyi.com>

--- a/README.md
+++ b/README.md
@@ -36,38 +36,6 @@ These metadata files are simply bencoded dictionaries.
 npm install bencode
 ```
 
-## Performance
-
-### encode buffer
-
-package     | version | op/sec
------------ | ------- | ---------
-bencode     | 0.12.0  |  *47,692*
-dht.js      | 0.2.16  |   43,908
-dht-bencode | 0.1.2   |   35,670
-bencoding   | 0.0.1   |   31,942
-bncode      | 0.5.3   |   25,097
-btparse     | 1.0.2   |        -
-
-### decode to buffer
-
-package     | version | op/sec
------------ | ------- | ------
-bencode     | 0.12.0  |  129,326
-dht.js      | 0.2.16  |   71,639
-dht-bencode | 0.1.2   |   89,285
-bencoding   | 0.0.1   |   97,285
-bncode      | 0.5.3   |   16,567
-btparse     | 1.0.2   | *155,660*
-
-_Benchmarks run on an Intel Core i7-4600M @ 2.90Ghz with node v7.8.0 & GNU/Linux 4.4.39_
-
-To run the benchmarks simply use
-
-```
-npm run benchmark
-```
-
 ## Usage
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ _Benchmarks run on an Intel Core i7-4600M @ 2.90Ghz with node v7.8.0 & GNU/Linux
 To run the benchmarks simply use
 
 ```
-npm run bench
+npm run benchmark
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bencode",
   "description": "Bencode de/encoder",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "bugs": {
     "url": "https://github.com/themasch/node-bencode/issues"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "nanobench": "^2.1.0",
     "standard": "^9.0.2",
     "tap-spec": "~4.1.0",
-    "tape": "~4.6.0"
+    "tape": "^4.6.3"
   },
   "keywords": [
     "bdecode",


### PR DESCRIPTION
- Drop support for Node 0.10, 0.12., add support for Node 8 & 9  (@jhermsmeier)
- Support for typed arrays (@jhermsmeier, @nazar-pc)

No actual public API has changed since 1.0. We just dropped support (as in "test coverage) for old node versions and added proper support for typed arrays. Updates from 1.0 to 2.0 should be smooth. 

Thanks to the contributors to this version. 