### PR TITLE
Fix deprecation warning on Buffer() constructor

### DIFF
--- a/lib/decode.js
+++ b/lib/decode.js
@@ -1,3 +1,5 @@
+var Buffer = require('safe-buffer').Buffer
+
 const INTEGER_START = 0x69 // 'i'
 const STRING_DELIM = 0x3A // ':'
 const DICTIONARY_START = 0x64 // 'd'
@@ -73,7 +75,7 @@ function decode (data, start, end, encoding) {
   decode.encoding = encoding || null
 
   decode.data = !(Buffer.isBuffer(data))
-    ? new Buffer(data)
+    ? Buffer.from(data)
     : data.slice(start, end)
 
   decode.bytes = decode.data.length

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -55,7 +55,7 @@ var buffD = Buffer.from('d')
 var buffL = Buffer.from('l')
 
 encode.buffer = function (buffers, data) {
-  buffers.push(new Buffer(data.length + ':'), data)
+  buffers.push(Buffer.from(data.length + ':'), data)
 }
 
 encode.string = function (buffers, data) {


### PR DESCRIPTION
There were still two instances of calling `new Buffer()`, which this updates to use `Buffer.from()`, while also adding use of `safe-buffer` in `lib/decode.js`