### PR TITLE
Add dedicated bencode.encodingLength() implementation

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -1,4 +1,5 @@
 var Buffer = require('safe-buffer').Buffer
+var { getType } = require('./util')
 
 /**
  * Encodes data in bencode.
@@ -25,20 +26,10 @@ function encode (data, buffer, offset) {
 encode.bytes = -1
 encode._floatConversionDetected = false
 
-encode.getType = function (value) {
-  if (Buffer.isBuffer(value)) return 'buffer'
-  if (Array.isArray(value)) return 'array'
-  if (ArrayBuffer.isView(value)) return 'arraybufferview'
-  if (value instanceof Number) return 'number'
-  if (value instanceof Boolean) return 'boolean'
-  if (value instanceof ArrayBuffer) return 'arraybuffer'
-  return typeof value
-}
-
 encode._encode = function (buffers, data) {
   if (data == null) { return }
 
-  switch (encode.getType(data)) {
+  switch (getType(data)) {
     case 'buffer': encode.buffer(buffers, data); break
     case 'object': encode.dict(buffers, data); break
     case 'array': encode.list(buffers, data); break

--- a/lib/encoding-length.js
+++ b/lib/encoding-length.js
@@ -1,0 +1,69 @@
+var { digitCount, getType } = require('./util')
+
+function listLength (list) {
+  var length = 1 + 1 // type marker + end-of-type marker
+
+  for (let value of list) {
+    length += encodingLength(value)
+  }
+
+  return length
+}
+
+function mapLength (map) {
+  var length = 1 + 1 // type marker + end-of-type marker
+
+  for (let [ key, value ] of map) {
+    let keyLength = Buffer.byteLength(key)
+    length += digitCount(keyLength) + 1 + keyLength
+    length += encodingLength(value)
+  }
+
+  return length
+}
+
+function objectLength (value) {
+  var length = 1 + 1 // type marker + end-of-type marker
+  var keys = Object.keys(value)
+
+  for (var i = 0; i < keys.length; i++) {
+    let keyLength = Buffer.byteLength(keys[i])
+    length += digitCount(keyLength) + 1 + keyLength
+    length += encodingLength(value[ keys[i] ])
+  }
+
+  return length
+}
+
+function stringLength (value) {
+  var length = Buffer.byteLength(value)
+  return digitCount(length) + 1 + length
+}
+
+function arrayBufferLength (value) {
+  var length = value.byteLength - value.byteOffset
+  return digitCount(length) + 1 + length
+}
+
+function encodingLength (value) {
+  var length = 0
+
+  if (value == null) return length
+
+  var type = getType(value)
+
+  switch (type) {
+    case 'buffer': return digitCount(value.length) + 1 + value.length
+    case 'arraybufferview': return arrayBufferLength(value)
+    case 'string': return stringLength(value)
+    case 'array': case 'set': return listLength(value)
+    case 'number': return 1 + digitCount(Math.floor(value)) + 1
+    case 'bigint': return 1 + value.toString().length + 1
+    case 'object': return objectLength(value)
+    case 'map': return mapLength(value)
+    default:
+      throw new TypeError(`Unsupported value of type "${type}"`)
+  }
+}
+
+module.exports = encodingLength

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,4 @@ bencode.decode = require('./decode')
  * @param  {Object|Array|Buffer|String|Number|Boolean} value
  * @return {Number} byteCount
  */
-bencode.byteLength = bencode.encodingLength = function (value) {
-  return bencode.encode(value).length
-}
+bencode.byteLength = bencode.encodingLength = require('./encoding-length')

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,23 @@
+var util = module.exports
+
+util.digitCount = function digitCount (value) {
+  // Add a digit for negative numbers, as the sign will be prefixed
+  var sign = value < 0 ? 1 : 0
+  // Guard against negative numbers & zero going into log10(),
+  // as that would return -Infinity
+  value = Math.abs(Number(value || 1))
+  return Math.floor(Math.log10(value)) + 1 + sign
+}
+
+util.getType = function getType (value) {
+  if (Buffer.isBuffer(value)) return 'buffer'
+  if (ArrayBuffer.isView(value)) return 'arraybufferview'
+  if (Array.isArray(value)) return 'array'
+  if (value instanceof Number) return 'number'
+  if (value instanceof Boolean) return 'boolean'
+  if (value instanceof Set) return 'set'
+  if (value instanceof Map) return 'map'
+  if (value instanceof String) return 'string'
+  if (value instanceof ArrayBuffer) return 'arraybuffer'
+  return typeof value
+}

--- a/test/encoding-length.test.js
+++ b/test/encoding-length.test.js
@@ -1,0 +1,50 @@
+var fs = require('fs')
+var path = require('path')
+var test = require('tape').test
+var bencode = require('..')
+
+var torrent = fs.readFileSync(
+  path.join(__dirname, '..', 'benchmark', 'test.torrent')
+)
+
+test('encoding-length', function (t) {
+  t.test('torrent', function (t) {
+    var value = bencode.decode(torrent)
+    var length = bencode.encodingLength(value)
+    t.plan(1)
+    t.equal(length, torrent.length)
+  })
+
+  t.test('returns correct length for empty dictionaries', function (t) {
+    t.plan(1)
+    t.equal(bencode.encodingLength({}), 2)
+  })
+
+  t.test('returns correct length for empty lists', function (t) {
+    t.plan(1)
+    t.equal(bencode.encodingLength({}), 2)
+  })
+
+  t.test('returns correct length for integers', function (t) {
+    t.plan(2)
+    t.equal(bencode.encodingLength(-0), 3) // i0e
+    t.equal(bencode.encodingLength(-1), 4) // i-1e
+  })
+
+  t.test('returns integer part length for floating point numbers', function (t) {
+    t.plan(1)
+    t.equal(bencode.encodingLength(100.25), 1 + 1 + 3)
+  })
+
+  t.test('returns correct length for BigInts', function (t) {
+    t.plan(1)
+    // 2n ** 128n == 340282366920938463463374607431768211456
+    t.equal(bencode.encodingLength(340282366920938463463374607431768211456), 1 + 1 + 39)
+  })
+
+  t.test('returns zero for undefined or null values', function (t) {
+    t.plan(2)
+    t.equal(bencode.encodingLength(null), 0)
+    t.equal(bencode.encodingLength(undefined), 0)
+  })
+})

--- a/test/encoding-length.test.js
+++ b/test/encoding-length.test.js
@@ -16,13 +16,34 @@ test('encoding-length', function (t) {
   })
 
   t.test('returns correct length for empty dictionaries', function (t) {
-    t.plan(1)
-    t.equal(bencode.encodingLength({}), 2)
+    t.plan(2)
+    t.equal(bencode.encodingLength({}), 2) // de
+    t.equal(bencode.encodingLength(new Map()), 2) // de
+  })
+
+  t.test('returns correct length for dictionaries', function (t) {
+    t.plan(2)
+    var obj = { a: 1, b: 'str', c: { de: 'f' } }
+    var map = new Map([
+      [ 'a', 1 ],
+      [ 'b', 'str' ],
+      [ 'c', { de: 'f' } ]
+    ])
+    t.equal(bencode.encodingLength(obj), 28) // d1:ai1e1:b3:str1:cd2:de1:fee
+    t.equal(bencode.encodingLength(map), 28) // d1:ai1e1:b3:str1:cd2:de1:fee
   })
 
   t.test('returns correct length for empty lists', function (t) {
-    t.plan(1)
-    t.equal(bencode.encodingLength({}), 2)
+    t.plan(2)
+    t.equal(bencode.encodingLength([]), 2) // le
+    t.equal(bencode.encodingLength(new Set()), 2) // le
+  })
+
+  t.test('returns correct length for lists', function (t) {
+    t.plan(3)
+    t.equal(bencode.encodingLength([1, 2, 3]), 11) // li1ei2ei3ee
+    t.equal(bencode.encodingLength([1, 'string', [{ a: 1, b: 2 }]]), 29) // li1e6:stringld1:ai1e1:bi2eeee
+    t.equal(bencode.encodingLength(new Set([1, 'string', [{ a: 1, b: 2 }]])), 29) // li1e6:stringld1:ai1e1:bi2eeee
   })
 
   t.test('returns correct length for integers', function (t) {


### PR DESCRIPTION
This adds a standalone implementation for `.encodingLength(value)`,
which is significantly faster than encoding & getting the length from
the returned buffer.

This will also enable us to pre-allocate a correctly sized buffer when
encoding, potentially enabling performance improvements, as we can avoid
allocating a large amount of small buffers followed by concatenation,
and instead write directly into the pre-allocated buffer.

Further, `.encodingLength()` supports new types for lists and
dictionaries; namely `Set`s and `Map`s