### PR TITLE
Add support for encoding Maps and Sets

### DIFF
--- a/lib/encode.js
+++ b/lib/encode.js
@@ -108,7 +108,6 @@ encode.dictMap = function (buffers, data) {
 
   var keys = Array.from(data.keys()).sort()
 
-  // Sort keys to retain
   for (var key of keys) {
     if (data.get(key) == null) continue
     Buffer.isBuffer(key)

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -111,7 +111,9 @@ encode.dictMap = function (buffers, data) {
   // Sort keys to retain
   for (var key of keys) {
     if (data.get(key) == null) continue
-    encode._encode(buffers, key)
+    Buffer.isBuffer(key)
+      ? encode._encode(buffers, key)
+      : encode.string(buffers, String(key))
     encode._encode(buffers, data.get(key))
   }
 

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -41,6 +41,7 @@ encode._encode = function (buffers, data) {
   switch (encode.getType(data)) {
     case 'buffer': encode.buffer(buffers, data); break
     case 'object': encode.dict(buffers, data); break
+    case 'map': encode.dictMap(buffers, data); break
     case 'array': encode.list(buffers, data); break
     case 'string': encode.string(buffers, data); break
     case 'number': encode.number(buffers, data); break
@@ -94,6 +95,20 @@ encode.dict = function (buffers, data) {
     if (data[k] == null) continue
     encode.string(buffers, k)
     encode._encode(buffers, data[k])
+  }
+
+  buffers.push(buffE)
+}
+
+encode.dictMap = function (buffers, data) {
+  buffers.push(buffD)
+
+  var keys = Array.from(data.keys()).sort()
+
+  // Sort keys to retain
+  for (var key of keys) {
+    encode._encode(buffers, key)
+    encode._encode(buffers, data.get(key))
   }
 
   buffers.push(buffE)

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -43,6 +43,7 @@ encode._encode = function (buffers, data) {
     case 'object': encode.dict(buffers, data); break
     case 'map': encode.dictMap(buffers, data); break
     case 'array': encode.list(buffers, data); break
+    case 'set': encode.listSet(buffers, data); break
     case 'string': encode.string(buffers, data); break
     case 'number': encode.number(buffers, data); break
     case 'boolean': encode.number(buffers, data); break
@@ -123,6 +124,17 @@ encode.list = function (buffers, data) {
   for (; i < c; i++) {
     if (data[i] == null) continue
     encode._encode(buffers, data[i])
+  }
+
+  buffers.push(buffE)
+}
+
+encode.listSet = function (buffers, data) {
+  buffers.push(buffL)
+
+  for (var item of data) {
+    if (item == null) continue
+    encode._encode(buffers, item)
   }
 
   buffers.push(buffE)

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -107,6 +107,7 @@ encode.dictMap = function (buffers, data) {
 
   // Sort keys to retain
   for (var key of keys) {
+    if (data.get(key) == null) continue
     encode._encode(buffers, key)
     encode._encode(buffers, data.get(key))
   }

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -31,6 +31,8 @@ encode.getType = function (value) {
   if (ArrayBuffer.isView(value)) return 'arraybufferview'
   if (value instanceof Number) return 'number'
   if (value instanceof Boolean) return 'boolean'
+  if (value instanceof Set) return 'set'
+  if (value instanceof Map) return 'map'
   if (value instanceof ArrayBuffer) return 'arraybuffer'
   return typeof value
 }

--- a/test/encode.test.js
+++ b/test/encode.test.js
@@ -31,6 +31,16 @@ test('bencode#encode()', function (t) {
     t.equal(bencode.encode(data).toString(), 'd2:1211:Hello World2:34i12345ee')
   })
 
+  t.test('should encode a Map as dictionary', function (t) {
+    t.plan(1)
+    var data = new Map([
+      [ 12, 'Hello World' ],
+      [ '34', 12345 ],
+      [ Buffer.from('buffer key'), Buffer.from('buffer value') ]
+    ])
+    t.equal(bencode.encode(data).toString(), 'd2:1211:Hello World2:34i12345e10:buffer key12:buffer valuee')
+  })
+
   t.test('should be able to encode a positive integer', function (t) {
     t.plan(1)
     t.equal(bencode.encode(123).toString(), 'i123e')

--- a/test/encode.test.js
+++ b/test/encode.test.js
@@ -120,6 +120,11 @@ test('bencode#encode()', function (t) {
     t.equal(bencode.encode([32, 12]).toString(), 'li32ei12ee')
     t.equal(bencode.encode([':asdf:']).toString(), 'l6::asdf:e')
   })
+  t.test('should be able to encode a Set as a list', function (t) {
+    t.plan(2)
+    t.equal(bencode.encode(new Set([32, 12])).toString(), 'li32ei12ee')
+    t.equal(bencode.encode(new Set([':asdf:'])).toString(), 'l6::asdf:e')
+  })
   t.test('should be able to encode an object', function (t) {
     t.plan(3)
     t.equal(bencode.encode({ 'a': 'bc' }).toString(), 'd1:a2:bce')


### PR DESCRIPTION
This adds support for encoding `Map`s and `Set` through `bencode.encode()`