### PR TITLE
Update node versions, drop v4/v6, add v10/v12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
   - stable
+  - 12
+  - 10
   - 8
-  - 6
-  - 4
 script:
   - npm test


### PR DESCRIPTION
As noted on #89, this drops CI tests for Node versions 6 and 8, while adding versions 10 and 12 to the matrix